### PR TITLE
SLK-103546 - Add Token Authentication Fallback Support

### DIFF
--- a/modules/project_attachment/trigger-gcp.py
+++ b/modules/project_attachment/trigger-gcp.py
@@ -49,10 +49,19 @@ def get_headers(cspm_key, cspm_method='GET', body_cspm=''):
         body      =body_cspm
     )
 
+    tokens_signature = get_signature(
+        api_secret=aqua_api_secret,
+        timestamp=timestamp,
+        path="/v2/tokens",
+        method="POST",
+        body='{"validity":1,"allowed_endpoints":["ANY"]}'
+    )
+
     headers = {
         "X-API-Key": aqua_api_key,
         "X-Authenticate-Api-Key-Signature": internal_signature,
         "X-Register-New-Cspm-Signature": signature_cspm_keys,
+        "X-Tokens-Signature": tokens_signature,
         "X-Timestamp": timestamp,
         "Content-Type": "application/json"
     }


### PR DESCRIPTION
- Add X-Tokens-Signature header to all API key-authenticated requests
- Calculate tokens signature using existing get_signature function with /v2/tokens endpoint
- Update trigger-aws.py: add header to get_cspm_key_id(), trigger_discovery(), and update_credentials() functions
- Update create_cspm_key.py: add header to get_cspm_key_id() and create_cspm_key() functions
- Update generate_external_id.py: add header to generate_external_id() function
- Enable backend fallback to Bearer token authentication when API key authentication fails